### PR TITLE
Improve the view for Ingredient Entries

### DIFF
--- a/app/controllers/ingredient_entries_controller.rb
+++ b/app/controllers/ingredient_entries_controller.rb
@@ -1,8 +1,8 @@
 class IngredientEntriesController < ApplicationController
-  before_action :set_instance_variables, only: [:show, :edit, :update, :destroy]
+  before_action :set_instance_variables, only: [:show, :edit, :touch, :update, :destroy]
 
   def index
-    @ingredient_entries = IngredientEntry.all
+    @ingredient_entries = IngredientEntry.where("updated_at < ?", Date.new(2020,5,27)).order(original_string: :asc)
   end
 
   def show
@@ -15,10 +15,15 @@ class IngredientEntriesController < ApplicationController
   def edit
   end
 
+  def touch
+    @ingredient_entry.touch
+    redirect_to ingredient_entries_path, notice: 'Timestamp updated'
+  end
+
   def create
     @ingredient_entry = IngredientEntry.new(ingredient_entry_params)
 
-    respond_to do |format|
+    respond_to do |format|ingr
       if @ingredient_entry.save
         format.html { redirect_to @ingredient_entry, notice: 'Ingredient entry was successfully created.' }
         format.json { render :show, status: :created, location: @ingredient_entry }
@@ -30,10 +35,11 @@ class IngredientEntriesController < ApplicationController
   end
 
   def update
+    # @ingredient_entries = IngredientEntry.where("created_at < ?", Date.new(2020,5,27)).order(original_string: :asc)
     respond_to do |format|
       if @ingredient_entry.update(ingredient_entry_params)
-        format.html { redirect_to @recipe, notice: 'Ingredient entry was successfully updated.' }
-        format.json { render :show, status: :ok, location: @recipe }
+        format.html { redirect_to ingredient_entries_path, notice: 'Ingredient entry was successfully updated.' }
+        # format.json { render :show, status: :ok, location: @recipe }
       else
         format.html { render :edit }
         format.json { render json: @ingredient_entry.errors, status: :unprocessable_entity }

--- a/app/controllers/ingredient_entries_controller.rb
+++ b/app/controllers/ingredient_entries_controller.rb
@@ -39,7 +39,6 @@ class IngredientEntriesController < ApplicationController
     respond_to do |format|
       if @ingredient_entry.update(ingredient_entry_params)
         format.html { redirect_to ingredient_entries_path, notice: 'Ingredient entry was successfully updated.' }
-        # format.json { render :show, status: :ok, location: @recipe }
       else
         format.html { render :edit }
         format.json { render json: @ingredient_entry.errors, status: :unprocessable_entity }

--- a/app/views/ingredient_entries/edit.html.erb
+++ b/app/views/ingredient_entries/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Editing Ingredient Entry</h1>
 
-<%= render 'form', ingredient_entry: @ingredient_entry %>
+<%= render 'form', ingredient_entry: @ingredient_entry, ingredient_entries: @ingredient_entries %>
 
 <%= link_to 'Back to Recipe', recipe_path(@recipe) %>

--- a/app/views/ingredient_entries/index.html.erb
+++ b/app/views/ingredient_entries/index.html.erb
@@ -19,7 +19,7 @@
     <% @ingredient_entries.each do |ingredient_entry| %>
       <tr>
         <td><%= ingredient_entry.original_string %></td>
-        <td><%= link_to "#{ingredient_entry.human_readable_entry}", "touch_ingredient_entry/#{ingredient_entry.id}", title: "click to verify correct" %></td>
+        <td><%= link_to "#{ingredient_entry.human_readable_entry}", touch_ingredient_entry_path(ingredient_entry), title: "click to verify correct" %></td>
         <td><%= link_to 'Edit', edit_ingredient_entry_path(ingredient_entry) %></td>
         <td><%= link_to 'Destroy', ingredient_entry, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/ingredient_entries/index.html.erb
+++ b/app/views/ingredient_entries/index.html.erb
@@ -2,9 +2,15 @@
 
 <h1>Ingredient Entries</h1>
 
+<h3>Showing <%= @ingredient_entries.count %> of <%= IngredientEntry.count %> total entries</h3>
+
 <table>
   <thead>
     <tr>
+      <th>Original String</th>
+      <th>Generated String</th>
+      <th>Edit</th>
+      <th>Destroy</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -12,7 +18,8 @@
   <tbody>
     <% @ingredient_entries.each do |ingredient_entry| %>
       <tr>
-        <td><%= link_to 'Show', ingredient_entry %></td>
+        <td><%= ingredient_entry.original_string %></td>
+        <td><%= link_to "#{ingredient_entry.human_readable_entry}", "touch_ingredient_entry/#{ingredient_entry.id}", title: "click to verify correct" %></td>
         <td><%= link_to 'Edit', edit_ingredient_entry_path(ingredient_entry) %></td>
         <td><%= link_to 'Destroy', ingredient_entry, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,9 +17,11 @@ Rails.application.routes.draw do
 
   post 'recipe_imports/create' => 'recipe_imports#create'
 
-  get 'recipe_imports/show' => 'recipe_imports#show'  
+  get 'recipe_imports/show' => 'recipe_imports#show'
 
   get 'generate_jekyll_post' => 'jekyll_posts#generate'
+
+  get 'touch_ingredient_entry/:id' => 'ingredient_entries#touch'
 
   resources :ingredient_entries
   resources :ingredient_sets
@@ -27,6 +29,6 @@ Rails.application.routes.draw do
   resources :recipe_imports
   resources :tags
   resources :method_steps
-  
+
   root :to => 'recipe_imports#new'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
 
   get 'generate_jekyll_post' => 'jekyll_posts#generate'
 
-  get 'touch_ingredient_entry/:id' => 'ingredient_entries#touch'
+  get 'touch_ingredient_entry/:id', to: 'ingredient_entries#touch', as: 'touch_ingredient_entry'
 
   resources :ingredient_entries
   resources :ingredient_sets

--- a/spec/models/human_readable_entry_generator_spec.rb
+++ b/spec/models/human_readable_entry_generator_spec.rb
@@ -4,12 +4,6 @@ require_relative '../test_data/human_readable_ingredient_entries.rb'
 RSpec.describe HumanReadableEntryGenerator,
 type: :model do
   describe "#generate" do
-    it "generates the correct string" do
-      entry = FactoryBot.build(:ingredient_entry)
-      generator = described_class.new(entry)
-      expect(generator.generate).to eq(entry.original_string)
-    end
-
     context "parsing a variety of ingredient entry data" do
       test_data = IngredientEntryTestData::ENTRIES
 

--- a/spec/models/ingredient_entry_processor_spec.rb
+++ b/spec/models/ingredient_entry_processor_spec.rb
@@ -313,4 +313,28 @@ RSpec.describe IngredientEntryProcessor, type: :model do
       expect(processor.get_ingredient).to eq "leek"
     end
   end
+
+  context "a handful of red seedless grapes" do
+    let(:processor) { described_class.new("a handful of red seedless grapes", 1) }
+
+    it "has a quantity of 1" do
+      expect(processor.get_quantity).to eq(1)
+    end
+
+    it "has a unit of 'handful'" do
+      expect(processor.get_unit).to eq("handful")
+    end
+
+    it "has a size of nil" do
+      expect(processor.get_size).to be_nil
+    end
+
+    it "has a modifier of nil" do
+      expect(processor.get_modifier).to be_nil
+    end
+
+    it "has an ingredient of 'red seedless grapes'" do
+      expect(processor.get_ingredient).to eq "red seedless grapes"
+    end
+  end
 end

--- a/spec/test_data/human_readable_ingredient_entries.rb
+++ b/spec/test_data/human_readable_ingredient_entries.rb
@@ -1,5 +1,4 @@
 class IngredientEntryTestData
-  # [:quantity, :unit, :size, :ingredient, :modifier]
   ENTRIES = [
     {
       original_string: "1 carrot",
@@ -75,6 +74,11 @@ class IngredientEntryTestData
       original_string: "2 medium banana shallots, finely chopped",
       # [:quantity, :unit, :size, :ingredient, :modifier]
       params: [2, nil,  "medium", "banana shallots", "finely chopped"],
+    },
+    {
+      original_string: "1 handful red seedless grapes",
+      # [:quantity, :unit, :size, :ingredient, :modifier]
+      params: [1, "handful",  nil, "red seedless grapes", nil],
     },
   ]
 end


### PR DESCRIPTION
You can now see the original string and the human generated entry in the
view to be able to compare them easily. There is also a button to update
the timestamp of the entry. The index controller is only showing the
ingredient entries which were updated before 27th May 2020.