### PR TITLE
Fix the view for Ingredient Entries

### DIFF
--- a/app/controllers/ingredient_entries_controller.rb
+++ b/app/controllers/ingredient_entries_controller.rb
@@ -2,7 +2,15 @@ class IngredientEntriesController < ApplicationController
   before_action :set_instance_variables, only: [:show, :edit, :touch, :update, :destroy]
 
   def index
-    @ingredient_entries = IngredientEntry.where("updated_at < ?", Date.new(2020,5,27)).order(original_string: :asc)
+    @ingredient_entries = IngredientEntry.all
+
+    @old_ingredient_entries = IngredientEntry
+                                .where("updated_at < ?", Date.today)
+                                .order(original_string: :asc)
+
+    @recently_updated_ingredient_entries = IngredientEntry
+                                .where("updated_at >= ?", Date.today)
+                                .order(original_string: :asc)
   end
 
   def show
@@ -64,6 +72,6 @@ class IngredientEntriesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def ingredient_entry_params
-      params.require(:ingredient_entry).permit(:quantity, :unit, :size, :modifier, :original_string)
+      params.require(:ingredient_entry).permit(:quantity, :unit, :size, :modifier, :original_string, :ingredient)
     end
 end

--- a/app/models/human_readable_entry_generator.rb
+++ b/app/models/human_readable_entry_generator.rb
@@ -30,14 +30,14 @@ class HumanReadableEntryGenerator
   end
 
   def get_unit
-    return "" if unit.nil?
+    return "" if blank?(unit)
     return " #{unit.to_s}" unless unit_is_irregular?
 
     quantity.to_i > 1 ? " #{unit.pluralize.to_s}" : " #{unit.singularize.to_s}"
   end
 
   def get_size
-    size.nil? ? "" : " #{size}"
+    blank?(size) ? "" : " #{size}"
   end
 
   def get_ingredient
@@ -45,7 +45,11 @@ class HumanReadableEntryGenerator
   end
 
   def get_modifier
-    modifier.nil? ? "" : ", #{modifier}"
+    blank?(modifier) ? "" : ", #{modifier}"
+  end
+
+  def blank?(attribute)
+    attribute.nil? || attribute == ""
   end
 
   def set_instance_variables

--- a/app/views/ingredient_entries/index.html.erb
+++ b/app/views/ingredient_entries/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Ingredient Entries</h1>
 
-<h3>Showing <%= @ingredient_entries.count %> of <%= IngredientEntry.count %> total entries</h3>
+<h4>Last Updated Ingredient Entry:</h4>
 
 <table>
   <thead>
@@ -16,7 +16,32 @@
   </thead>
 
   <tbody>
-    <% @ingredient_entries.each do |ingredient_entry| %>
+    <% @recently_updated_ingredient_entries.each do |ingredient_entry| %>
+      <tr>
+        <td><%= ingredient_entry.original_string %></td>
+        <td><%= link_to "#{ingredient_entry.human_readable_entry}", touch_ingredient_entry_path(ingredient_entry), title: "click to verify correct" %></td>
+        <td><%= link_to 'Edit', edit_ingredient_entry_path(ingredient_entry) %></td>
+        <td><%= link_to 'Destroy', ingredient_entry, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<h4>Older Entries:</h4>
+
+<table>
+  <thead>
+    <tr>
+      <th>Original String</th>
+      <th>Generated String</th>
+      <th>Edit</th>
+      <th>Destroy</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @old_ingredient_entries.each do |ingredient_entry| %>
       <tr>
         <td><%= ingredient_entry.original_string %></td>
         <td><%= link_to "#{ingredient_entry.human_readable_entry}", touch_ingredient_entry_path(ingredient_entry), title: "click to verify correct" %></td>

--- a/spec/test_data/human_readable_ingredient_entries.rb
+++ b/spec/test_data/human_readable_ingredient_entries.rb
@@ -80,5 +80,10 @@ class IngredientEntryTestData
       # [:quantity, :unit, :size, :ingredient, :modifier]
       params: [1, "handful",  nil, "red seedless grapes", nil],
     },
+    {
+      original_string: "1 bay leaf",
+      # [:quantity, :unit, :size, :ingredient, :modifier]
+      params: [1.0, "",  "", "bay leaf", ""],
+    },
   ]
 end


### PR DESCRIPTION
The accepted params did not include :ingredient so it was silently
failing in the controller. This PR fixes that, and also adds a separate
table for recently updated ingredient entries (updated on the current
day). This PR also addresses an issue whereby attributes on the
IngredientEntry that were empty strings, rather than nil, were not being
processed correctly.