### PR TITLE
Add quantityless column to IngredientEntry table

### DIFF
--- a/app/controllers/ingredient_entries_controller.rb
+++ b/app/controllers/ingredient_entries_controller.rb
@@ -48,7 +48,7 @@ class IngredientEntriesController < ApplicationController
   def update
     respond_to do |format|
       if @ingredient_entry.update(ingredient_entry_params)
-        format.html { redirect_to recipe_path(@recipe), id: @recipe.id, notice: 'Ingredient entry was successfully updated.' }
+        format.html { redirect_to recipe_path(@recipe), notice: 'Ingredient entry was successfully updated.' }
       else
         format.html { render :edit }
         format.json { render json: @ingredient_entry.errors, status: :unprocessable_entity }

--- a/app/controllers/ingredient_entries_controller.rb
+++ b/app/controllers/ingredient_entries_controller.rb
@@ -48,7 +48,7 @@ class IngredientEntriesController < ApplicationController
   def update
     respond_to do |format|
       if @ingredient_entry.update(ingredient_entry_params)
-        format.html { redirect_to ingredient_entries_path, notice: 'Ingredient entry was successfully updated.' }
+        format.html { redirect_to recipe_path(@recipe), id: @recipe.id, notice: 'Ingredient entry was successfully updated.' }
       else
         format.html { render :edit }
         format.json { render json: @ingredient_entry.errors, status: :unprocessable_entity }
@@ -74,6 +74,6 @@ class IngredientEntriesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def ingredient_entry_params
-      params.require(:ingredient_entry).permit(:quantity, :unit, :size, :modifier, :original_string, :ingredient)
+      params.require(:ingredient_entry).permit(:quantity, :unit, :size, :modifier, :original_string, :ingredient, :quantityless)
     end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -76,11 +76,10 @@ class RecipesController < ApplicationController
 
   def set_recipe
     # Confusingly, `recipe_title` is usually the permalink of the recipe, but sometimes the ID
-    @recipe = Recipe.all.find { |recipe| recipe.permalink == "/#{params[:recipe_title]}" }
+    recipe_from_permalink = Recipe.all.find { |recipe| recipe.permalink == "/#{params[:recipe_title]}" }
+    recipe_from_id = Recipe.find_by_id(params[:recipe_title])
 
-    unless @recipe
-      @recipe = Recipe.find(params[:recipe_title])
-    end
+    @recipe = recipe_from_permalink || recipe_from_id
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -75,7 +75,12 @@ class RecipesController < ApplicationController
   private
 
   def set_recipe
+    # Confusingly, `recipe_title` is usually the permalink of the recipe, but sometimes the ID
     @recipe = Recipe.all.find { |recipe| recipe.permalink == "/#{params[:recipe_title]}" }
+
+    unless @recipe
+      @recipe = Recipe.find(params[:recipe_title])
+    end
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/models/human_readable_entry_generator.rb
+++ b/app/models/human_readable_entry_generator.rb
@@ -13,7 +13,7 @@ class HumanReadableEntryGenerator
   end
 
   def generate
-    return original_string if special_entry?
+    return original_string if special_entry? || ingredient_entry.quantityless?
     get_quantity +
     get_unit +
     get_size +

--- a/app/views/ingredient_entries/_form.html.erb
+++ b/app/views/ingredient_entries/_form.html.erb
@@ -41,6 +41,11 @@
     <%= form.text_field :original_string, id: :original_string %>
   </div>
 
+  <div class="field">
+    <%= form.label :quantityless? %>
+    <%= form.check_box :quantityless, id: :quantityless %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -40,7 +40,7 @@
         <hr />
         <ul>
           <% @recipe.ingredient_entries.each do |entry| %>
-            <li><%= entry.human_readable_entry %></li>
+            <li><%= entry.human_readable_entry %> (<%= link_to "edit", edit_ingredient_entry_path(entry) %>)</li>
           <% end %>
         </ul>
 

--- a/db/migrate/20200730191905_add_quantityless_to_ingredient_entries.rb
+++ b/db/migrate/20200730191905_add_quantityless_to_ingredient_entries.rb
@@ -1,0 +1,5 @@
+class AddQuantitylessToIngredientEntries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ingredient_entries, :quantityless, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_195830) do
+ActiveRecord::Schema.define(version: 2020_07_30_191905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_195830) do
     t.string "written_quantity"
     t.string "written_unit"
     t.string "ingredient"
+    t.boolean "quantityless"
     t.index ["ingredient_set_id"], name: "index_ingredient_entries_on_ingredient_set_id"
   end
 


### PR DESCRIPTION
This column allows arbitrarily flagging an ingredient entry as not
having a quantity, meaning that it's much easier to construct the human
readable entry. Previously we were relying on an array of "special
entries" and matching on those.