### PR TITLE
Display fractions instead of decimals

### DIFF
--- a/app/models/human_readable_entry_generator.rb
+++ b/app/models/human_readable_entry_generator.rb
@@ -25,8 +25,8 @@ class HumanReadableEntryGenerator
 
   def get_quantity
     return "" if quantity.nil?
-    return "1/2" if quantity_is_half_as_fraction?
-
+    return fractional_quantity if quantity_should_be_a_fraction?
+    # This ensures we display "5" instead of "5.0", for example
     return quantity.to_i.to_s if quantity.to_f.floor == quantity.to_f
 
     quantity
@@ -80,7 +80,20 @@ class HumanReadableEntryGenerator
     IngredientEntryProcessor::SPECIAL_ENTRIES.include?(original_string.strip)
   end
 
-  def quantity_is_half_as_fraction?
-    quantity == "0.5" && original_string =~ /^1\/2/
+  def quantity_should_be_a_fraction?
+    %w(0.5 0.25 0.75 0.125 0.333 0.666).include?(quantity)
+  end
+
+  def fractional_quantity
+    decimal_to_fraction_map = {
+      "0.5"   => "½",
+      "0.25"  => "¼",
+      "0.75"  => "¾",
+      "0.125" => "⅛",
+      "0.333" => "⅓",
+      "0.666" => "⅔",
+    }
+
+    decimal_to_fraction_map[quantity]
   end
 end

--- a/app/models/ingredient_entry_processor.rb
+++ b/app/models/ingredient_entry_processor.rb
@@ -1,3 +1,7 @@
+# This class is concerned with taking the inputted string
+# from the RecipeImport, eg: "10 g tomatoes, chopped" and
+# parsing it into the quantity, unit etc. The reverse process
+# is handled by HumanReadableEntryGenerator
 class IngredientEntryProcessor
 
 	SIZES = %w(small medium large generous)

--- a/spec/models/human_readable_entry_generator_spec.rb
+++ b/spec/models/human_readable_entry_generator_spec.rb
@@ -8,20 +8,23 @@ type: :model do
       test_data = IngredientEntryTestData::ENTRIES
 
       test_data.each do |hash|
-        it "#{hash[:original_string]} has a human readable string equal to the original one" do
+        it "'#{hash[:expected_output]}' has a human readable string equal to the expected one" do
 
-          params = {
+          entry_params = {
             quantity: hash[:params][0],
             unit: hash[:params][1],
             size: hash[:params][2],
             ingredient: hash[:params][3],
             modifier: hash[:params][4],
-            original_string: hash[:original_string]
+            quantityless: hash[:params][5],
+            original_string: hash[:expected_output]
           }
+          entry = IngredientEntry.create(entry_params)
 
-          entry = IngredientEntry.create(params)
+          generated_output = described_class.new(entry).generate
+          expected_output = hash[:expected_output]
 
-          expect(described_class.new(entry).generate).to eq(hash[:original_string])
+          expect(generated_output).to eq(expected_output)
         end
       end
     end

--- a/spec/test_data/human_readable_ingredient_entries.rb
+++ b/spec/test_data/human_readable_ingredient_entries.rb
@@ -1,95 +1,109 @@
 class IngredientEntryTestData
   ENTRIES = [
     {
-      original_string: "1 carrot",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [1, nil,  nil, "carrot", nil]
+      expected_output: "1 carrot",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [1, nil,  nil, "carrot", nil, false]
     },
     {
-      original_string: "100 g plain flour",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [100, "g",  nil, "plain flour", nil]
+      expected_output: "100 g plain flour",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [100, "g",  nil, "plain flour", nil, false]
     },
     {
-      original_string: "10 g carrot, diced",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [10, "g",  nil, "carrot", "diced"]
+      expected_output: "10 g carrot, diced",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [10, "g",  nil, "carrot", "diced", false]
     },
     {
-      original_string: "25 large tomatoes, peeled and chopped",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [25, nil,  "large", "tomatoes", "peeled and chopped"]
+      expected_output: "25 large tomatoes, peeled and chopped",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [25, nil,  "large", "tomatoes", "peeled and chopped", false]
     },
     {
-      original_string: "3 handfuls basil, leaves picked",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [3, "handful",  nil, "basil", "leaves picked"]
+      expected_output: "3 handfuls basil, leaves picked",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [3, "handful",  nil, "basil", "leaves picked", false]
     },
     {
-      original_string: "3 large cloves garlic, chopped",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [3, "large clove",  nil, "garlic", "chopped"]
+      expected_output: "3 large cloves garlic, chopped",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [3, "large clove",  nil, "garlic", "chopped", false]
     },
     {
-      original_string: "vegetable oil, for frying",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [nil, nil,  nil, "vegetable oil, for frying", nil]
+      expected_output: "vegetable oil, for frying",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [nil, nil,  nil, "vegetable oil, for frying", nil, true]
     },
     {
-      original_string: "2 small cloves garlic",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [2, "small clove",  nil, "garlic", nil]
+      expected_output: "2 small cloves garlic",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [2, "small clove",  nil, "garlic", nil, false]
     },
     {
-      original_string: "750 g cavolo nero",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [750, "g",  nil, "cavolo nero", nil]
+      expected_output: "750 g cavolo nero",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [750, "g",  nil, "cavolo nero", nil, false]
     },
     {
-      original_string: "1 tsp extra virgin olive oil",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [1, "tsp",  nil, "extra virgin olive oil", nil]
+      expected_output: "1 tsp extra virgin olive oil",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [1, "tsp",  nil, "extra virgin olive oil", nil, false]
     },
     {
-      original_string: "1 pinch ground asafoetida",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [1, "pinch",  nil, "ground asafoetida", nil]
+      expected_output: "1 pinch ground asafoetida",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [1, "pinch",  nil, "ground asafoetida", nil, false]
     },
     {
-      original_string: "sea salt and freshly cracked black pepper",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [nil, nil,  nil, "sea salt and freshly cracked black pepper", nil]
+      expected_output: "sea salt and freshly cracked black pepper",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [nil, nil,  nil, "sea salt and freshly cracked black pepper", nil, true]
     },
     {
-      original_string: "1/2 leek",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [0.5, nil,  nil, "leek", nil],
+      expected_output: "½ leek",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [0.5, nil,  nil, "leek", nil, false]
     },
     {
-      original_string: "250 g cream cheese",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [250, "g",  nil, "cream cheese", nil],
+      expected_output: "250 g cream cheese",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [250, "g",  nil, "cream cheese", nil, false]
     },
     {
-      original_string: "2 medium banana shallots, finely chopped",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [2, nil,  "medium", "banana shallots", "finely chopped"],
+      expected_output: "2 medium banana shallots, finely chopped",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [2, nil,  "medium", "banana shallots", "finely chopped", false]
     },
     {
-      original_string: "1 handful red seedless grapes",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [1, "handful",  nil, "red seedless grapes", nil],
+      expected_output: "1 handful red seedless grapes",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [1, "handful",  nil, "red seedless grapes", nil, false]
     },
     {
-      original_string: "1 bay leaf",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [1.0, "",  "", "bay leaf", ""],
+      expected_output: "1 bay leaf",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [1.0, "",  "", "bay leaf", "", false]
     },
     {
-      original_string: "0.5 lime, juice of",
-      # [:quantity, :unit, :size, :ingredient, :modifier]
-      params: [0.5, "",  "", "lime", "juice of"],
+      expected_output: "½ lime, juice of",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [0.5, "",  "", "lime", "juice of", false]
     },
-
+    {
+      expected_output: "¼ tsp chilli powder",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [0.25, "tsp",  "", "chilli powder", "", false]
+    },
+    {
+      expected_output: "⅛ tsp chilli powder",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [0.125, "tsp",  "", "chilli powder", "", false]
+    },
+    {
+      expected_output: "⅔ tsp chilli powder",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [0.666, "tsp",  "", "chilli powder", "", false]
+    },
   ]
 end


### PR DESCRIPTION
For ingredient entries with a quantity of either 0.5, 0.25, 0.125, 0.333
or 0.666, we will display a fraction instead of a decimal. This will
apply mostly to teaspoon units.