### PR TITLE
Adds link to edit form for method step to recipe show page

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -18,8 +18,11 @@ class RecipesController < ApplicationController
       MarkdownConverter.convert(paragraph)
     end
 
-    @method_steps = @recipe.method_steps.order(:position).map do |method_step|
-      MarkdownConverter.convert(method_step.description)
+    @method_steps_with_description = @recipe.method_steps.order(:position).map do |method_step|
+      OpenStruct.new(
+        method_step: method_step,
+        description: MarkdownConverter.convert(method_step.description)
+      )
     end
 
     @ingredient_entries = @recipe.ingredient_entries

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -59,8 +59,15 @@
         </ul>
 
         <ol>
-          <% @method_steps.each do |method_step| %>
-            <li><p><%= simple_format(method_step) %></p></li>
+          <% @method_steps_with_description.each do |obj| %>
+            <li>
+              <p>
+                <%= simple_format(obj.description) %>
+                <% if admin_session?  %>
+                  (<%= link_to "edit", edit_method_step_path(obj.method_step) %>)
+                <% end %>
+              </p>
+            </li>
           <% end %>
         </ol>
       </div>


### PR DESCRIPTION
This PR adds some logic to the recipe controller to manipulate the
method steps into an array of OpenStruct objects with two attributes:
the original method step and the markdown-formatted description. This
makes it simple to loop through them in the view.