### PR TITLE
Handle brackets as modifier

### DIFF
--- a/app/models/human_readable_entry_generator.rb
+++ b/app/models/human_readable_entry_generator.rb
@@ -48,7 +48,13 @@ class HumanReadableEntryGenerator
   end
 
   def get_modifier
-    blank?(modifier) ? "" : ", #{modifier}"
+    if ingredient_entry.original_string =~ /\(/
+      mod = " (#{modifier})"
+    else
+      mod = ", #{modifier}"
+    end
+
+    blank?(modifier) ? "" : mod
   end
 
   def blank?(attribute)

--- a/app/models/ingredient_entry_processor.rb
+++ b/app/models/ingredient_entry_processor.rb
@@ -39,7 +39,6 @@ class IngredientEntryProcessor
 
 
 	def get_modifier
-
 		# Handles the case where there are brackets instead of
 		# a comma. Assumes there isn't both a comma and brackets.
 		if @ingredient_entry_string.match(/(\(.+\))/)

--- a/spec/integration/recipe_import_spec.rb
+++ b/spec/integration/recipe_import_spec.rb
@@ -152,7 +152,21 @@ RSpec.describe "Importing a Recipe from a YAML file" do
       it_behaves_like("attributes are correct", expected_attributes)
     end
 
-    xcontext "10 carrots, cut into 5mm dice" do
+    context "100g cavolo nero (black kale)" do
+      expected_attributes = {
+        quantity: 100,
+        unit: "g",
+        size: nil,
+        modifier: "black kale",
+        ingredient: "cavolo nero"
+      }
+
+      let(:original_string) { "100g cavolo nero (black kale)" }
+
+      it_behaves_like("attributes are correct", expected_attributes)
+    end
+
+    context "10 carrots, cut into 5mm dice" do
       expected_attributes = {
         quantity: 10,
         unit: nil,

--- a/spec/models/ingredient_entry_processor_spec.rb
+++ b/spec/models/ingredient_entry_processor_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe IngredientEntryProcessor, type: :model do
       expect(processor.get_size).to be_nil
     end
 
-    it "has a modifier of '(black kale)'" do
-      expect(processor.get_modifier).to eq "(black kale)"
+    it "has a modifier of 'black kale'" do
+      expect(processor.get_modifier).to eq "black kale"
     end
 
     it "has an ingredient of 'cavolo nero'" do
@@ -335,6 +335,30 @@ RSpec.describe IngredientEntryProcessor, type: :model do
 
     it "has an ingredient of 'red seedless grapes'" do
       expect(processor.get_ingredient).to eq "red seedless grapes"
+    end
+  end
+
+  context "10 carrots, cut into 5mm dice" do
+    let(:processor) { described_class.new("10 carrots, cut into 5mm dice", 1) }
+
+    it "has a quantity of 10" do
+      expect(processor.get_quantity).to eq(10)
+    end
+
+    it "has a unit of nil" do
+      expect(processor.get_unit).to be_nil
+    end
+
+    it "has a size of nil" do
+      expect(processor.get_size).to be_nil
+    end
+
+    it "has a modifier of nil" do
+      expect(processor.get_modifier).to eq("cut into 5mm dice")
+    end
+
+    it "has an ingredient of 'carrots'" do
+      expect(processor.get_ingredient).to eq "carrots"
     end
   end
 end

--- a/spec/test_data/benchmark_test_recipe.yaml
+++ b/spec/test_data/benchmark_test_recipe.yaml
@@ -21,6 +21,7 @@ first_ingredient_set:
     - 1/2 handful of pinenuts
     - 2 x 400g tins tomatoes
     - 10 carrots, cut into 5mm dice
+    - 100g cavolo nero (black kale)
 
 second_ingredient_set:
   to finish:

--- a/spec/test_data/human_readable_ingredient_entries.rb
+++ b/spec/test_data/human_readable_ingredient_entries.rb
@@ -105,5 +105,10 @@ class IngredientEntryTestData
       # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
       params: [0.666, "tsp",  "", "chilli powder", "", false]
     },
+    {
+      expected_output: "10 g cavolo nero (black kale)",
+      # [:quantity, :unit, :size, :ingredient, :modifier, :quantityless]
+      params: [10, "g",  "", "cavolo nero", "black kale", false]
+    },
   ]
 end


### PR DESCRIPTION
Previously modifiers were only separated by a comma, and some original
strings were not handled properly such as "cavolo nero (black kale)".

This commit also fixes the issue where, if `5mm` was included in the
modifier, "mm" was incorrectly set as the unit.